### PR TITLE
RST-71 separate odom and tf publication

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_diff_drive.h
@@ -124,6 +124,7 @@ namespace gazebo {
       std::string odometry_topic_;
       std::string odometry_frame_;
       std::string robot_base_frame_;
+      bool publish_odom_;
       bool publish_tf_;
       bool legacy_mode_;
       // Custom Callback Queue


### PR DESCRIPTION
For some reason, the diff drive controller doesn't have separate parameters for odometry data and odom->base_link tf publication. This is required for our setup. Will repeat this change for indigo when approved.

@locusrobotics/robot-software-team 